### PR TITLE
공지사항 정렬 및 팝업 개선, 영문 주소 및 디자인 수정

### DIFF
--- a/src/app/content/contact/style.css
+++ b/src/app/content/contact/style.css
@@ -154,6 +154,37 @@
     font-weight: 500;
 }
 
+/* 영문 주소 단어 단위 줄바꿈 */
+.english_contact_page .location_info_content_wrapper .info_text {
+    font-size: 16px;
+    letter-spacing: -0.1px;
+    word-break: normal;
+    overflow-wrap: normal;
+}
+
+.address_no_wrap {
+    white-space: nowrap;
+}
+
+.english_contact_page .compact_address {
+    font-size: 15px;
+    letter-spacing: -0.2px;
+    white-space: nowrap;
+}
+
+/* 영문 Contact 정보 간격 */
+.english_contact_page .location_info_wrapper {
+    justify-content: flex-start;
+}
+
+.english_contact_page .location_info_lane_wrapper:nth-child(2) {
+    margin-top: 40px;
+}
+
+.english_contact_page .location_info_lane_wrapper:nth-child(3) {
+    margin-top: 15px;
+}
+
 /* 오시는 방법 컨테이너 */
 .come_way_wrapper {
     width: 100%;
@@ -258,6 +289,12 @@
         flex-direction: column;
     }
 
+    .english_contact_page .location_info_lane_wrapper:nth-child(2),
+    .english_contact_page .location_info_lane_wrapper:nth-child(3) {
+        margin-top: 0;
+        transform: none;
+    }
+
     .location_info_content_wrapper {
         gap: 2px;
     }
@@ -270,6 +307,13 @@
     .info_sub_title,
     .info_text {
         font-size: 13px;
+    }
+
+    .english_contact_page .location_info_content_wrapper .info_text,
+    .english_contact_page .compact_address {
+        font-size: 13px;
+        letter-spacing: normal;
+        white-space: normal;
     }
 
     .come_way_wrapper {

--- a/src/app/en/content/contact/page.tsx
+++ b/src/app/en/content/contact/page.tsx
@@ -9,11 +9,13 @@ import MetaTagTitle from '@/utils/MetaTagTitle';
 import { GoogleMap, LoadScript, Marker } from '@react-google-maps/api';
 import { isLoading } from '@/modules/loading';
 import { useRecoilState } from 'recoil';
+import { useMediaQuery } from 'react-responsive';
 
 export default function ContactMap() {
 
     const [, setLoading] = useRecoilState(isLoading);
     const googleAppKey = process.env.NEXT_PUBLIC_GOOGLE_API_KEY || '';
+    const isMobile = useMediaQuery({ maxWidth: 1170 });
 
     const [location, setLocation] = useState<any>({
         lat: 0,
@@ -48,7 +50,7 @@ export default function ContactMap() {
     }, [address]);
 
     return (
-        <article>
+        <article className='english_contact_page'>
             <MetaTagTitle title='Location' ko={false} />
             <PageHeader />
             <PageBanner pageTitle='Location' />
@@ -77,42 +79,47 @@ export default function ContactMap() {
                             <ul className='location_info_wrapper'>
                                 <li className='location_info_lane_wrapper'>
                                     <strong className='location_info_category'>
-                                        <div className='category_under_bar' />
-                                        Address
+                                        Addr.
                                     </strong>
                                     <div className='location_info_content_wrapper'>
                                         <span className='info_sub_title'>
-                                            Office.
+                                            Headquarters
                                         </span>
-                                        <p className='info_text'>
-                                            #422, 307, Waryong-ro, Seo-gu, Daegu, Republic of Korea
+                                        <p className='info_text compact_address'>
+                                            #422, D-center1976, 307 Waryong-ro, Seo-gu, Daegu, <span className='address_no_wrap'>Republic of Korea</span>
                                         </p>
                                         <span
-                                            style={{ marginTop: '24px' }}
+                                            style={{ marginTop: (isMobile) ? '10px' : '24px' }}
                                             className='info_sub_title'>
-                                            Research Institute.
+                                            Corporate Research Institute
+                                        </span>
+                                        <p className='info_text compact_address'>
+                                            #424, D-center1976, 307 Waryong-ro, Seo-gu, Daegu, <span className='address_no_wrap'>Republic of Korea</span>
+                                        </p>
+                                        <span
+                                            style={{ marginTop: (isMobile) ? '10px' : '24px' }}
+                                            className='info_sub_title'>
+                                            Corporate Research Institute&nbsp;&nbsp;– Jeonbuk
                                         </span>
                                         <p className='info_text'>
-                                            #424, 307, Waryong-ro, Seo-gu, Daegu, Republic of Korea
+                                            #209, 13-6 Iksan-daero 78-gil, Hamyeol-eup, Iksan-si, <span className='address_no_wrap'>Jeonbuk-do</span>, <span className='address_no_wrap'>Republic of Korea</span>
                                         </p>
                                     </div>
                                 </li>
                                 <li className='location_info_lane_wrapper'>
                                     <strong className='location_info_category'>
-                                        <div className='category_under_bar' />
-                                        Call Number
+                                        Tel.
                                     </strong>
                                     <p className='info_text'>
-                                        053-716-0816
+                                        +82-53-716-0816
                                     </p>
                                 </li>
                                 <li className='location_info_lane_wrapper'>
                                     <strong className='location_info_category'>
-                                        <div className='category_under_bar' />
-                                        E-mail
+                                        Fax
                                     </strong>
                                     <p className='info_text'>
-                                        info@zefit.co.kr
+                                        +82-53-719-0654
                                     </p>
                                 </li>
                             </ul>

--- a/src/app/en/notice/page.tsx
+++ b/src/app/en/notice/page.tsx
@@ -50,6 +50,7 @@ export default function NoticeEN() {
                     .from('notices')
                     .select('*')
                     .ilike(dropdownValue?.value, `%${search}%`)
+                    .order('created_at', { ascending: false })
                     .range(start, end);
                 if (error) {
                     throw error;
@@ -150,7 +151,7 @@ export default function NoticeEN() {
             try {
                 const [special, normal, total] = await Promise.all([
                     supabase.from('notices').select('*').eq('is_special', true),
-                    supabase.from('notices').select('*').eq('is_special', false).range(start, end),
+                    supabase.from('notices').select('*').eq('is_special', false).order('created_at', { ascending: false }).range(start, end),
                     supabase.from('notices').select('*', { count: 'exact' })
                 ]);
 

--- a/src/app/en/page.tsx
+++ b/src/app/en/page.tsx
@@ -55,7 +55,7 @@ export default function HomeEN() {
                     .select('*')
                     .eq('is_special', true)
                     .order('created_at', { ascending: false })
-                    .limit(1);
+                    .limit(3);
                 if (error) {
                     throw error;
                 }

--- a/src/app/notice/page.tsx
+++ b/src/app/notice/page.tsx
@@ -50,6 +50,7 @@ export default function Notice() {
                     .from('notices')
                     .select('*')
                     .ilike(dropdownValue?.value, `%${search}%`)
+                    .order('created_at', { ascending: false })
                     .range(start, end);
                 if (error) {
                     throw error;
@@ -149,8 +150,8 @@ export default function Notice() {
         const fetchData = async () => {
             try {
                 const [special, normal, total] = await Promise.all([
-                    supabase.from('notices').select('*').eq('is_special', true),
-                    supabase.from('notices').select('*').eq('is_special', false).range(start, end),
+                    supabase.from('notices').select('*').eq('is_special', true).order('created_at', { ascending: false }),
+                    supabase.from('notices').select('*').eq('is_special', false).order('created_at', { ascending: false }).range(start, end),
                     supabase.from('notices').select('*', { count: 'exact' })
                 ]);
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -49,7 +49,7 @@ export default function Home() {
                     .select('*')
                     .eq('is_special', true)
                     .order('created_at', { ascending: false })
-                    .limit(1);
+                    .limit(3);
                 if (error) {
                     throw error;
                 }

--- a/src/components/common/Popup/index.tsx
+++ b/src/components/common/Popup/index.tsx
@@ -1,11 +1,10 @@
 'use client';
 
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilState } from 'recoil';
 import './style.css';
 import { isPopup } from '@/modules/popupModal';
 import { useEffect, useRef, useState } from 'react';
 import { usePathname } from 'next/navigation';
-import { isLoading } from '@/modules/loading';
 
 interface PopupProps {
     popupData: any;
@@ -15,9 +14,19 @@ export default function Popup({ popupData }: PopupProps) {
 
     const path = usePathname() as string;
     const isEnglish = path?.includes('/en');
-    const popupValue = (popupData) ? popupData[0] : null;
+    const popupCount = Array.isArray(popupData) ? popupData.length : 0;
+    const [currentIndex, setCurrentIndex] = useState<number>(0);
+    const popupValue = popupData?.[currentIndex] ?? null;
     const popupRef = useRef<HTMLDivElement>(null);
     const [popupOpen, setPopupOpen] = useRecoilState(isPopup);
+
+    const onClickPrevious = () => {
+        setCurrentIndex((current) => (current - 1 + popupCount) % popupCount);
+    };
+
+    const onClickNext = () => {
+        setCurrentIndex((current) => (current + 1) % popupCount);
+    };
 
     const onClickPopupSetCookie = () => {
         const now = new Date();
@@ -25,6 +34,10 @@ export default function Popup({ popupData }: PopupProps) {
         document.cookie = `zf-pov=${now.toISOString()}; expires=${expirationDate.toUTCString()}; path=/`;
         setPopupOpen(false);
     };
+
+    useEffect(() => {
+        setCurrentIndex(0);
+    }, [popupData]);
 
     useEffect(() => {
         if (!popupRef.current) return;
@@ -65,6 +78,40 @@ export default function Popup({ popupData }: PopupProps) {
                     className='popup_more_button'>
                     {(isEnglish) ? 'More' : '자세히 보기'}
                 </a>
+                {popupCount > 1 && (
+                    <>
+                        <button
+                            type='button'
+                            onClick={onClickPrevious}
+                            className='popup_navigation_button popup_previous_button'
+                            aria-label={(isEnglish) ? 'Previous notice' : '이전 공지'}>
+                            ‹
+                        </button>
+                        <button
+                            type='button'
+                            onClick={onClickNext}
+                            className='popup_navigation_button popup_next_button'
+                            aria-label={(isEnglish) ? 'Next notice' : '다음 공지'}>
+                            ›
+                        </button>
+                        <div
+                            className='popup_page_indicator'
+                            aria-label={`${currentIndex + 1} / ${popupCount}`}>
+                            {popupData.map((item: any, index: number) => (
+                                <button
+                                    key={item?.id ?? index}
+                                    type='button'
+                                    onClick={() => setCurrentIndex(index)}
+                                    className={`popup_page_dot${index === currentIndex ? ' popup_page_dot_active' : ''}`}
+                                    aria-label={(isEnglish)
+                                        ? `Go to notice ${index + 1}`
+                                        : `${index + 1}번째 공지로 이동`}
+                                    aria-current={(index === currentIndex) ? 'true' : undefined}
+                                />
+                            ))}
+                        </div>
+                    </>
+                )}
             </div>
             <div className='popup_button_wrapper'>
                 <button

--- a/src/components/common/Popup/style.css
+++ b/src/components/common/Popup/style.css
@@ -24,6 +24,7 @@
     width: 100%;
     height: 100%;
     padding: 30px 0px;
+    position: relative;
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -79,6 +80,73 @@
 /* 자세히 보기 버튼 HOVER효과 */
 .popup_more_button:hover {
     color: white;
+    background-color: #0055A7;
+}
+
+/* 팝업 공지 이전/다음 버튼 */
+.popup_navigation_button {
+    width: 44px;
+    height: 44px;
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border-radius: 50%;
+    color: #0055A7;
+    background-color: #ffffffd9;
+    font-size: 38px;
+    line-height: 1;
+    cursor: pointer;
+    transition: background-color 0.2s, color 0.2s;
+}
+
+.popup_navigation_button:hover {
+    color: white;
+    background-color: #0055A7;
+}
+
+.popup_previous_button {
+    left: 12px;
+}
+
+.popup_next_button {
+    right: 12px;
+}
+
+/* 팝업 공지 페이지 점 */
+.popup_page_indicator {
+    position: absolute;
+    bottom: 8px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    align-items: center;
+    gap: 2px;
+}
+
+.popup_page_dot {
+    width: 24px;
+    height: 32px;
+    position: relative;
+    cursor: pointer;
+}
+
+.popup_page_dot::before {
+    width: 8px;
+    height: 8px;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    border: 1px solid #0055A7;
+    border-radius: 50%;
+    background-color: white;
+    content: '';
+    transform: translate(-50%, -50%);
+}
+
+.popup_page_dot_active::before {
     background-color: #0055A7;
 }
 
@@ -154,6 +222,29 @@
         width: 110px;
         height: 36px;
         font-size: 14px;
+    }
+
+    .popup_navigation_button {
+        width: 48px;
+        height: 48px;
+        font-size: 36px;
+    }
+
+    .popup_previous_button {
+        left: 0;
+    }
+
+    .popup_next_button {
+        right: 0;
+    }
+
+    .popup_page_indicator {
+        bottom: 2px;
+    }
+
+    .popup_page_dot {
+        width: 32px;
+        height: 40px;
     }
 
     .popup_button_wrapper {


### PR DESCRIPTION
<비고>
- 국문 '오시는 길' 페이지 수정 후, 동일 변경사항이 영문 Contact 페이지에 반영되지 않아 추가 수정함.

1. Contact 페이지 수정 (영문)
- 전북 주소 추가
- 연락처 정보 수정 (e-mail 제거, fax 추가)
- 일부 용어 변경
- 레이아웃 및 간격 조정
2. 공지사항 개선 (한/영)
- 공지사항 목록 최신순 정렬(내림차) 적용
3. 메인 팝업 개선 (한/영)
- 중요 공지사항 최대 3건까지 팝업 표시
- 이전/다음 버튼 및 페이지 인디케이터 추가
- 팝업 순환(Carousel) 기능 추가
- 팝업이 1건일 경우 버튼 및 인디케이터 숨김
- 기존 오늘 하루 보지 않기 및 닫기 기능 유지
